### PR TITLE
select_biased! usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ crossbeam-channel = "0.5.13"
 wg_2024 = { git = "https://github.com/WGL-2024/WGL_repo_2024.git", features = ["serialize","debug"] }
 rand = "0.9.0-alpha.2"
 log = "0.4.22"
+once_cell = "1.20.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,12 @@ impl Drone for MyDrone {
         pdr: f32,
     ) -> Self {
         // TODO: decide if we need more input validation
+        // As the check below, can't we just use self.add_channel for each packet_send entry to avoid repeating any logic?
         assert!(
             !packet_send.contains_key(&id),
             "neighbor with id {id} which is the same as drone"
         );
+        // Can't we just re-use self.set_pdr to avoid repeating the range checking logic?
         assert!((0.0..=1.0).contains(&pdr), "pdr out of bounds");
         Self {
             id,
@@ -125,6 +127,10 @@ impl MyDrone {
     }
 
     fn add_channel(&mut self, id: NodeId, sender: Sender<Packet>) {
+        if id == self.id {
+            panic!("Cannot add a channel with the same NodeId of this drone");
+        }
+
         match self.packet_send.insert(id, sender) {
             Some(_previous_sender) => {
                 log::info!("Sender to node {id} updated");

--- a/tests/flooding.rs
+++ b/tests/flooding.rs
@@ -14,7 +14,7 @@ mod common;
 
 #[test]
 fn flood_request_propagation() {
-    let (event_send, event_recv, _, controller_recv, packet_send, packet_recv) = create_channels();
+    let (event_send, event_recv, _controller_send, controller_recv, packet_send, packet_recv) = create_channels();
 
     let (s2, r2) = unbounded::<Packet>();
     let (s3, r3) = unbounded::<Packet>();
@@ -90,7 +90,7 @@ fn flood_request_propagation() {
 
 #[test]
 fn flood_request_no_neighbors() {
-    let (event_send, event_recv, _, controller_recv, packet_send, packet_recv) = create_channels();
+    let (event_send, event_recv, _controller_send, controller_recv, packet_send, packet_recv) = create_channels();
 
     let (s2, r2) = unbounded::<Packet>();
     let mut senders = HashMap::new();

--- a/tests/initialization.rs
+++ b/tests/initialization.rs
@@ -7,7 +7,7 @@ use wg_2024::{drone::Drone, packet::Packet};
 mod common;
 
 #[test]
-#[should_panic(expected = "pdr out of bounds")]
+#[should_panic(expected = "Tried to set an invalid pdr value of 43.14, which is not in range (0.0..=1.0)")]
 fn pdr_too_big() {
     let (controller_send, _, _, controller_recv, _packet_send, packet_recv) = create_channels();
     let _my_drone = MyDrone::new(
@@ -21,7 +21,7 @@ fn pdr_too_big() {
 }
 
 #[test]
-#[should_panic(expected = "pdr out of bounds")]
+#[should_panic(expected = "Tried to set an invalid pdr value of -0.1, which is not in range (0.0..=1.0)")]
 fn pdr_negative() {
     let (controller_send, _, _, controller_recv, _packet_send, packet_recv) = create_channels();
     let _my_drone = MyDrone::new(
@@ -35,7 +35,7 @@ fn pdr_negative() {
 }
 
 #[test]
-#[should_panic(expected = "neighbor with id 1 which is the same as drone")]
+#[should_panic(expected = "Cannot add a channel with the same NodeId of this drone (which is 1)")]
 fn neighbor_is_self() {
     let (controller_send, _, _, controller_recv, _packet_send, packet_recv) = create_channels();
 


### PR DESCRIPTION
This PR solves some of the remaining TODOs in src/lib.rs. The most important part of this PR is the usage of select_biased! instead of select!. Note that this introduces the chance of starvation on the packet receiving channel. Specifically, select_biased! seems to select a channel even if one end of it gets dropped.
For instance, if I create a drone and drop the Sender<DroneCommand> channel and I keep using the drone, then the drone will always select the recv(self.controller_recv) arm, since it receives an Err(). This means that the drone stops working properly in the case of bad channels management. Interestingly, this doesn't occur with the select! macro.
An example of this can be found in the tests: 
1. in tests/flooding.rs, if you just use the "\_" variable to ignore the Sender<DroneCommand>, I guess that Rust immediately drops it, making all the flooding tests fail. If you just rename it to "\_controller\_send" instead of "\_", this doesn't happen
2. in tests/forwarding.rs, if you don't return the Sender<DroneCommand> channel from make\_forwarding\_drone(), the same issue arises. Just returning said channel without using it solves this.